### PR TITLE
Prevent PHP Fatal errors when the class is included multiple times

### DIFF
--- a/class.settings-api.php
+++ b/class.settings-api.php
@@ -7,6 +7,7 @@
  * @link http://tareq.weDevs.com Tareq's Planet
  * @example settings-api.php How to use the class
  */
+if ( !class_exists('WeDevs_Settings_API' ) ):
 class WeDevs_Settings_API {
 
     /**
@@ -378,3 +379,4 @@ class WeDevs_Settings_API {
     }
 
 }
+endif;


### PR DESCRIPTION
Hey,

Really dig your plugin, and use it in a couple of my own plugins. The problem arises when you enable two plugins with the same code, it starts throwing Fatal errors. So to avoid that we need to check if class exists or not. 
