### PR TITLE
Fix wp_editor responsiveness

### DIFF
--- a/class.settings-api.php
+++ b/class.settings-api.php
@@ -283,7 +283,7 @@ class WeDevs_Settings_API {
         $value = $this->get_option( $args['id'], $args['section'], $args['std'] );
         $size = isset( $args['size'] ) && !is_null( $args['size'] ) ? $args['size'] : '500px';
 
-        echo '<div style="width: ' . $size . ';">';
+        echo '<div style="max-width: ' . $size . ';">';
 
         $editor_settings = array(
             'teeny' => true,


### PR DESCRIPTION
When used fixed width smaller screens didn't shrink the width.
Setting to max-width will keep large screen the same as before but
smaller screen will have dynamic width.

Signed-off-by: Roi Dayan <roi.dayan@gmail.com>