### PR TITLE
Hide content during load

### DIFF
--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -451,7 +451,7 @@ class WeDevs_Settings_API {
         <div class="metabox-holder">
             <div class="postbox">
                 <?php foreach ( $this->settings_sections as $form ) { ?>
-                    <div id="<?php echo $form['id']; ?>" class="group">
+                    <div id="<?php echo $form['id']; ?>" class="group" style="display: none;">
                         <form method="post" action="options.php">
 
                             <?php do_action( 'wsa_form_top_' . $form['id'], $form ); ?>


### PR DESCRIPTION
When jquery is ready the content of the selected tab will be showen.
Before this commit during page load the user see a long scroll with
all the tabs content.

Signed-off-by: Roi Dayan <roi.dayan@gmail.com>