### PR TITLE
Allow to specify callback for section

### DIFF
--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -113,8 +113,10 @@ class WeDevs_Settings_API {
             if ( isset($section['desc']) && !empty($section['desc']) ) {
                 $section['desc'] = '<div class="inside">'.$section['desc'].'</div>';
                 $callback = create_function('', 'echo "'.str_replace('"', '\"', $section['desc']).'";');
+            } else if ( isset( $section['callback'] ) ) {
+                $callback = $section['callback'];
             } else {
-                $callback = '__return_false';
+                $callback = null;
             }
 
             add_settings_section( $section['id'], $section['title'], $callback, $section['id'] );


### PR DESCRIPTION
Can be used to output dynamic content when needed and not set in desc
in admin_init.
Also when callback is not needed set to null instead of __return_false to
avoid calling a function that does nothing.

Signed-off-by: Roi Dayan <roi.dayan@gmail.com>