### PR TITLE
Add label_for arg for fields

### DIFF
--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -130,6 +130,7 @@ class WeDevs_Settings_API {
 
                 $args = array(
                     'id' => $option['name'],
+                    'label_for' => $args['label_for'] = "{$section}[{$option['name']}]",
                     'desc' => isset( $option['desc'] ) ? $option['desc'] : '',
                     'name' => $option['label'],
                     'section' => $section,
@@ -139,6 +140,7 @@ class WeDevs_Settings_API {
                     'sanitize_callback' => isset( $option['sanitize_callback'] ) ? $option['sanitize_callback'] : '',
                     'type' => $type,
                 );
+
                 add_settings_field( $section . '[' . $option['name'] . ']', $option['label'], array( $this, 'callback_' . $type ), $section, $section, $args );
             }
         }


### PR DESCRIPTION
With this the Settings API will add the "for" attribute for labels.
With this clicking a label will focus on the relevant input.
This behavior is used across Wordpress options pages.

Signed-off-by: Roi Dayan <roi.dayan@gmail.com>