### PR TITLE
Refactor Browse string to Choose File

### DIFF
--- a/example/oop-example.php
+++ b/example/oop-example.php
@@ -130,7 +130,10 @@ class WeDevs_Settings_API_Test {
                     'label'   => __( 'File', 'wedevs' ),
                     'desc'    => __( 'File description', 'wedevs' ),
                     'type'    => 'file',
-                    'default' => ''
+                    'default' => '',
+                    'options' => array(
+                        'button_label' => 'Choose Image'
+                    )
                 )
             ),
             'wedevs_advanced' => array(

--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -343,9 +343,12 @@ class WeDevs_Settings_API {
         $value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
         $size = isset( $args['size'] ) && !is_null( $args['size'] ) ? $args['size'] : 'regular';
         $id = $args['section']  . '[' . $args['id'] . ']';
+        $label = isset( $args['options']['button_label'] ) ?
+                        $args['options']['button_label'] :
+                        __( 'Choose File' );
 
         $html  = sprintf( '<input type="text" class="%1$s-text wpsa-url" id="%2$s[%3$s]" name="%2$s[%3$s]" value="%4$s"/>', $size, $args['section'], $args['id'], $value );
-        $html .= '<input type="button" class="button wpsa-browse" value="'.__( 'Browse' ).'" />';
+        $html .= '<input type="button" class="button wpsa-browse" value="' . $label . '" />';
         $html .= $this->get_field_description( $args );
 
         echo $html;


### PR DESCRIPTION
Browse is not part of the Wordpress translatation file so it doesn't get
translated. Choose File is and will be translated according to the
langauge Wordpress is set.

Signed-off-by: Roi Dayan <roi.dayan@gmail.com>