### PR TITLE
when saving an empty multicheck, the $options passed to sanitize_opti…

### DIFF
--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -394,15 +394,18 @@ class WeDevs_Settings_API {
      * Sanitize callback for Settings API
      */
     function sanitize_options( $options ) {
-        foreach( $options as $option_slug => $option_value ) {
-            $sanitize_callback = $this->get_sanitize_callback( $option_slug );
+        if ( !is_null($options) ) {
+            foreach( $options as $option_slug => $option_value ) {
+                $sanitize_callback = $this->get_sanitize_callback( $option_slug );
 
-            // If callback is set, call it
-            if ( $sanitize_callback ) {
-                $options[ $option_slug ] = call_user_func( $sanitize_callback, $option_value );
-                continue;
+                // If callback is set, call it
+                if ( $sanitize_callback ) {
+                    $options[ $option_slug ] = call_user_func( $sanitize_callback, $option_value );
+                    continue;
+                }
             }
         }
+
 
         return $options;
     }


### PR DESCRIPTION
…ons() is null, which causes an error. I've added a check for is_null before trying to sanitize $options.