### PR TITLE
Fix PHP warning : When saving an empty multicheck

### DIFF
--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -389,6 +389,7 @@ class WeDevs_Settings_API {
      * Sanitize callback for Settings API
      */
     function sanitize_options( $options ) {
+    	if(!is_array($options)){return $options;}
         foreach( $options as $option_slug => $option_value ) {
             $sanitize_callback = $this->get_sanitize_callback( $option_slug );
 


### PR DESCRIPTION
Fix the warning: PHP Warning:  Invalid argument supplied for foreach....in WeDevs_Settings_API->sanitize_options()
If a settings page has only multicheck field and has no other type of field like text , and I try to save the settings with all checkbox unchek , then the WeDevs_Settings_API->sanitize_options() receive $option variable null. And causes a PHP warning. 

Here I check the $option is an array or not. if not then return $option