### PR TITLE
Fix saving empty multicheck section

### DIFF
--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -222,7 +222,7 @@ class WeDevs_Settings_API {
 
         $value = $this->get_option( $args['id'], $args['section'], $args['std'] );
         $html  = '<fieldset>';
-
+        $html .= sprintf( '<input type="hidden" name="%1$s[%2$s]" value="" />', $args['section'], $args['id'] );
         foreach ( $args['options'] as $key => $label ) {
             $checked = isset( $value[$key] ) ? $value[$key] : '0';
             $html    .= sprintf( '<label for="wpuf-%1$s[%2$s][%3$s]">', $args['section'], $args['id'], $key );


### PR DESCRIPTION
By adding an empty value we make sure http post will add the checkbox id
so get_option will see something is set and not return us the default.

Fixes #63

Signed-off-by: Roi Dayan <roi.dayan@gmail.com>