### PR TITLE
RFC / POC: Repeatable Settings Fields

### DIFF
--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -407,13 +407,23 @@ class WeDevs_Settings_API {
 
         // Add the repeatable
         $ex_data = json_decode($this->get_option( $args['id'], $args['section'], $args['std']), true);
+        $ex_keys = array_keys($ex_data);
+
         $html = '<div class="repeatable-container">';
-        
-        foreach ($args['children'] as $child) {
-            $html .= '<label for="'.$child['name'].'_{?}">'.$child['label'].'</label>';
-            $html .= '<input type="text" name="'.$child['name'].'_{?}" value="" id="'.$child['name'].'_{?}" data-parent="'.$args['id'].'" data-child="'.$child['name'].'"/>';
+
+        if (count($ex_keys) > 0) {
+            foreach ($ex_data[$ex_keys[0]] as $i=>$v) {
+                $html .= '<div class="field-group">';
+                foreach ($args['children'] as $child) {
+                    $html .= '<label for="'.$child['name'].'_{?}">'.$child['label'].'</label>';
+                    $html .= '<input type="text" name="'.$child['name'].'_{?}" value="'.$ex_data[$child['name']][$i].'" id="'.$child['name'].'_{?}" data-parent="'.$args['id'].'" data-child="'.$child['name'].'"/>';
+                }
+                $html .= '<input type="button" class="delete" value="X" />';
+                $html .= '</div>';
+            }
         }
-        $html .= '<input type="button" class="delete" value="X" />';
+        echo "ERIC YOU NEED TO WRITE A DELETE CALL BACK";
+
         $html .= '</div><input type="button" value="Add" class="add" />';
         $html .= '<input type="hidden" name="'.$args["section"].'['.$args['id'].']" id="'.$args['section'].'_'.$args["id"].'"/>';
         echo $html;

--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -394,7 +394,7 @@ class WeDevs_Settings_API {
 
 
     /**
-     * Displays a repeatable for a settings field.
+     * Displays a repeatable for a settings field.  Sanitization, is applied to the final field.
      *
      * @param array   $args settings field args
      */
@@ -416,13 +416,12 @@ class WeDevs_Settings_API {
                 $html .= '<div class="field-group">';
                 foreach ($args['children'] as $child) {
                     $html .= '<label for="'.$child['name'].'_{?}">'.$child['label'].'</label>';
-                    $html .= '<input type="text" name="'.$child['name'].'_{?}" value="'.$ex_data[$child['name']][$i].'" id="'.$child['name'].'_{?}" data-parent="'.$args['id'].'" data-child="'.$child['name'].'"/>';
+                    $html .= '<input type="text" name="'.$child['name'].'_ex'.$i.'" value="'.$ex_data[$child['name']][$i].'" id="'.$child['name'].'_ex'.$i.'" data-parent="'.$args['id'].'" data-child="'.$child['name'].'"/>';
                 }
                 $html .= '<input type="button" class="delete" value="X" />';
                 $html .= '</div>';
             }
         }
-        echo "ERIC YOU NEED TO WRITE A DELETE CALL BACK";
 
         $html .= '</div><input type="button" value="Add" class="add" />';
         $html .= '<input type="hidden" name="'.$args["section"].'['.$args['id'].']" id="'.$args['section'].'_'.$args["id"].'"/>';
@@ -456,9 +455,7 @@ class WeDevs_Settings_API {
 		                	data['<?php echo $child["name"];?>'].push(jQuery(el).val());
 		                });
 		            <?php endforeach;?>
-
-                    console.log(JSON.stringify(data));
-
+                    
                     jQuery("#<?php echo $args["section"];?>_<?php echo $args['id'];?>").val(JSON.stringify(data));
 	            });
             </script>

--- a/src/js/jquery.repeatable.js
+++ b/src/js/jquery.repeatable.js
@@ -1,0 +1,142 @@
+/*-------------------------------------------
+ * https://github.com/jenwachter/jquery.repeatable
+ *------------------------------------------*/
+
+(function ($) {
+
+	$.fn.repeatable = function (userSettings) {
+
+		/**
+		 * Default settings
+		 * @type {Object}
+		 */
+		var defaults = {
+			addTrigger: ".add",
+			deleteTrigger: ".delete",
+			max: null,
+			startWith: 0,
+			template: null,
+			itemContainer: ".field-group",
+			beforeAdd: function () {},
+			afterAdd: function () {},
+			beforeDelete: function () {},
+			afterDelete: function () {}
+		};
+
+		/**
+		 * Iterator used to make each added
+		 * repeatable element unique
+		 * @type {Number}
+		 */
+		var i = 0;
+		
+		/**
+		 * DOM element into which repeatable
+		 * items will be added
+		 * @type {jQuery object}
+		 */
+		var target = $(this);
+			
+		/**
+		 * Blend passed user settings with defauly settings
+		 * @type {array}
+		 */
+		var settings = $.extend({}, defaults, userSettings);
+		
+		/**
+		 * Total templated items found on the page
+		 * at load. These may be created by server-side
+		 * scripts.
+		 * @return null
+		 */
+		var total = function () {
+			return $(target).find(settings.itemContainer).length;
+		}();
+
+		
+		/**
+		 * Add an element to the target
+		 * and call the callback function
+		 * @param  object e Event
+		 * @return null
+		 */
+		var addOne = function (e) {
+			e.preventDefault();
+			settings.beforeAdd.call(this);
+			createOne();
+			settings.afterAdd.call(this);
+		};
+
+		/**
+		 * Delete the parent element
+		 * and call the callback function
+		 * @param  object e Event
+		 * @return null
+		 */
+		var deleteOne = function (e) {
+			e.preventDefault();
+			settings.beforeDelete.call(this);
+			$(this).parents(settings.itemContainer).first().remove();
+			total--;
+			maintainAddBtn();
+			settings.afterDelete.call(this);
+		};
+
+		/**
+		 * Add an element to the target
+		 * @return null
+		 */
+		var createOne = function() {
+			getUniqueTemplate().appendTo(target);
+			total++;
+			maintainAddBtn();
+		};
+
+		/**
+		 * Alter the given template to make
+		 * each form field name unique
+		 * @return {jQuery object}
+		 */
+		var getUniqueTemplate = function () {
+			var template = $(settings.template).html();
+			template = template.replace(/{\?}/g, "new" + i++); 	// {?} => iterated placeholder
+			template = template.replace(/\{[^\?\}]*\}/g, ""); 	// {valuePlaceholder} => ""
+			return $(template);
+		};
+
+		/**
+		 * Determines if the add trigger
+		 * needs to be disabled
+		 * @return null
+		 */
+		var maintainAddBtn = function () {
+			if (!settings.max) {
+				return;
+			}
+
+			if (total === settings.max) {
+				$(settings.addTrigger).attr("disabled", "disabled");
+			} else if (total < settings.max) {
+				$(settings.addTrigger).removeAttr("disabled");
+			}
+		};
+
+		/**
+		 * Setup the repeater
+		 * @return null
+		 */
+		(function () {
+			$(settings.addTrigger).on("click", addOne);
+			$("form").on("click", settings.deleteTrigger, deleteOne);
+
+			if (!total) {
+				var toCreate = settings.startWith - total;
+				for (var j = 0; j < toCreate; j++) {
+					createOne();
+				}
+			}
+			
+		})();
+	};
+
+})(jQuery);

--- a/src/js/jquery.repeatable.js
+++ b/src/js/jquery.repeatable.js
@@ -1,4 +1,5 @@
 /*-------------------------------------------
+ * This is basically just a cut and paste of the below
  * https://github.com/jenwachter/jquery.repeatable
  *------------------------------------------*/
 


### PR DESCRIPTION
Hi Tareq, thanks for writing this I found it really helped speed up creating a WP plugin recently for a client, and a heap easier to work with than the existing WP settings API! 

This PR is really not right to merge, it's more a POC or discussion starter about introducing repeatables as field type.  If it's of interest I will refine so it can be merged.

###Overview###

This PR introduces a new field type repeatable created exactly the same was as existing field types.  A repeatable is simply a container for other fields of the standard field types that are in the children array of the repeatable.  See below:

```
					array(
						'name'    => 'repeatable',
						'label'   => __( 'A repeatable group', 'wpbstyledcalc' ),
						'desc'    => __( 'A repetable group', 'wpbstyledcalc' ),
						'type'    => 'repeatable',
						'children' => array(
							array(
								'name'              => 'big_tolerance',
								'label'             => __( 'Big Tolerances', 'wpbstyledcalc' ),
								'desc'              => __( 'What value should we use for the larger tolerance', 'wpbstyledcalc' ),
								'placeholder'       => __( 'Big Tolerance...', 'wpbstyledcalc' ),
								'type'              => 'text',
								'default'           => '25',
							),
							array(
								'name'              => 'small_tolerance',
								'label'             => __( 'Small Tolerances', 'wpbstyledcalc' ),
								'desc'              => __( 'What value should we use for the small tolerance', 'wpbstyledcalc' ),
								'placeholder'       => __( 'Small Tolerance...', 'wpbstyledcalc' ),
								'type'              => 'text',
								'default'           => '25',
							),
						)
					)
```

This would show up in the settings page as:

![2016-10-19_07-10-56](https://cloud.githubusercontent.com/assets/9042878/19496647/bd6dc87c-95cb-11e6-88cc-2b3f183aa4d5.png)

On the form submit the data is json encoded into a hidden input field that matches the top level name of the repeatable type.  In this case repeatable.

On the form display the JSON encoded option is parsed and the data used to populate the children element array.

The Add button will add a new row and the X button will delete an existing row.

### Work to Be Done ###

If there's interest in adding this feature the main work that still needs to be done is to move fields other than text into the repeatable when creating the child fields for the markup.

**Currently the only field that works as a repeatable child is a text field**

To do this properly I would probably slightly modify the existing callback_type methods to allow their use in the repeatable as well as stand alone fields.

I would also like to remove some of the inline javascript and move into the jquery.repeatable.js file.
