### PR TITLE
Adds a pages field type to display list of pages

### DIFF
--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -406,6 +406,24 @@ class WeDevs_Settings_API {
         echo $html;
     }
 
+
+    /**
+     * Displays a select box for creating the pages select box
+     *
+     * @param array   $args settings field args
+     */
+    function callback_pages( $args ) {
+
+        $dropdown_args = array(
+            'selected' => esc_attr($this->get_option($args['id'], $args['section'], $args['std'] ) ),
+            'name'     => $args['section'] . '[' . $args['id'] . ']',
+            'id'       => $args['section'] . '[' . $args['id'] . ']',
+            'echo'     => 0
+        );
+        $html = wp_dropdown_pages( $dropdown_args );
+        echo $html;
+    }
+
     /**
      * Sanitize callback for Settings API
      *


### PR DESCRIPTION
This PR just adds a select box with a list of pages to the available settings fields.

The select box is generated using wp_dropdown_pages and uses the args passed to the callback_pages function to make sure it's saved to the settings.

Eric.
![2016-11-10_17-32-46](https://cloud.githubusercontent.com/assets/9042878/20168141/f3b7eb54-a76b-11e6-9818-67ef8b8a44ae.png)
