### PR TITLE
Active tab highlight override from url hash

### DIFF
--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -571,7 +571,7 @@ class WeDevs_Settings_API {
                 if(window.location.hash){
                     activetab = window.location.hash;
                     if (typeof(localStorage) != 'undefined' ) {
-                        localStorage.setItem("activetab", activetabuonline);
+                        localStorage.setItem("activetab", activetab);
                     }                
                 } 
                 

--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -566,6 +566,15 @@ class WeDevs_Settings_API {
                 if (typeof(localStorage) != 'undefined' ) {
                     activetab = localStorage.getItem("activetab");
                 }
+                
+                //if url has section id as hash then set it as active or override the current local storage value
+                if(window.location.hash){
+                    activetab = window.location.hash;
+                    if (typeof(localStorage) != 'undefined' ) {
+                        localStorage.setItem("activetab", activetabuonline);
+                    }                
+                } 
+                
                 if (activetab != '' && $(activetab).length ) {
                     $(activetab).fadeIn();
                 } else {


### PR DESCRIPTION
if url has section id as hash then set it as active or override the current local storage value
Here is an exmaple from a practical plugin integration 
wp-admin/options-general.php?page=cbxuseronline#cbxuseronline_dash_widget where #cbxuseronline_dash_widget is id of a section.