### PR TITLE
fix validation for input type number

### DIFF
--- a/src/class.settings-api.php
+++ b/src/class.settings-api.php
@@ -204,8 +204,8 @@ class WeDevs_Settings_API {
         $size        = isset( $args['size'] ) && !is_null( $args['size'] ) ? $args['size'] : 'regular';
         $type        = isset( $args['type'] ) ? $args['type'] : 'number';
         $placeholder = empty( $args['placeholder'] ) ? '' : ' placeholder="' . $args['placeholder'] . '"';
-        $min         = empty( $args['min'] ) ? '' : ' min="' . $args['min'] . '"';
-        $max         = empty( $args['max'] ) ? '' : ' max="' . $args['max'] . '"';
+        $min         = !isset( $args['min'] ) ? '' : ' min="' . $args['min'] . '"';
+        $max         = !isset( $args['max'] ) ? '' : ' max="' . $args['max'] . '"';
         $step        = empty( $args['max'] ) ? '' : ' step="' . $args['step'] . '"';
 
         $html        = sprintf( '<input type="%1$s" class="%2$s-number" id="%3$s[%4$s]" name="%3$s[%4$s]" value="%5$s"%6$s%7$s%8$s%9$s/>', $type, $size, $args['section'], $args['id'], $value, $placeholder, $min, $max, $step );
@@ -566,15 +566,15 @@ class WeDevs_Settings_API {
                 if (typeof(localStorage) != 'undefined' ) {
                     activetab = localStorage.getItem("activetab");
                 }
-                
+
                 //if url has section id as hash then set it as active or override the current local storage value
                 if(window.location.hash){
                     activetab = window.location.hash;
                     if (typeof(localStorage) != 'undefined' ) {
                         localStorage.setItem("activetab", activetab);
-                    }                
-                } 
-                
+                    }
+                }
+
                 if (activetab != '' && $(activetab).length ) {
                     $(activetab).fadeIn();
                 } else {


### PR DESCRIPTION
The input type validation is not working when the min or max set to 0.

This is because of the `empty()` function 

```
$min         = empty( $args['min'] ) ? '' : ' min="' . $args['min'] . '"';
$min         = empty( 0 ) ? '' : ' min="' . $args['min'] . '"';
```

`empty( 0 ) ` Return true always so empty string store in a variable. 